### PR TITLE
Remove duplicate material-yew link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,13 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 - [yew-mdc](https://github.com/dungeonfog/yew-mdc) - Material Design Components for the Yew framework.
 - [muicss-yew](https://github.com/AlephAlpha/muicss-yew) - MUI-CSS Components for Yew framework.
 - [yew-bulma](https://github.com/kellpossible/yew-bulma) - A Rust library providing components based on the bulma css library for projects using Yew.
-- [yew-material-components](https://github.com/hamza1311/yew-material-components) - Yew material components.
+- [material-yew](https://github.com/hamza1311/material-yew) - Yew wrapper for Material Web Components.
 - [Yewprint](https://github.com/cecton/yewprint) - Port of blueprintjs.com to Yew.
 - [ybc](https://github.com/thedodd/ybc) - A Yew component library based on the Bulma CSS framework.
 - [patternfly-yew](https://github.com/ctron/patternfly-yew) - Patternfly components for Yew.
 - [yew-feather](https://github.com/pedrodesu/yew-feather) - Feather Icons components for Yew.
 - [tailwind-yew-builder](https://github.com/matiu2/tailwind-yew-builder) - Builds Tailwind CSS for Yew using docker-compose. Also supports Trunk.
 - [yew-components](https://github.com/angular-rust/yew-components) - Material Design Components for the Yew framework.
-- [material-yew](https://github.com/hamza1311/material-yew) - Yew wrapper for Material Web Components.
 
 ### Components
 


### PR DESCRIPTION
Going to https://github.com/hamza1311/yew-material-components redirects you to https://github.com/hamza1311/material-yew, which is what this project was renamed to.

I've removed the duplicate link and updated the original link to point to the correct URL.

**Related commits:**
- https://github.com/hamza1311/material-yew/commit/43bbb82afe60974a94f59d789efe39f4c1cbf6e6
- https://github.com/hamza1311/material-yew/commit/63efbf8a59bd166bfe7a5c9d6649f6866518b860