### PR TITLE
chore: add theiskaa.com under the projects tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 - [Portfolio website](https://github.com/simbleau/website) - A portfolio SPA with accessibility built-in by Spencer Imbleau.
 - [tchatche.rs](https://github.com/nag763/tchatchers) - A Websocket chat based application built in Yew and Axum.
 - [viz.rs](https://github.com/viz-rs/viz-rs.github.io) - A website for viz web framework, [Live Demo](https://viz.rs/).
+- [theiskaa.com](https://github.com/theiskaa/theiskaa.com) - A real world implementation of Yew framework. [Live at theiskaa.com](https://theiskaa.com)
 
 ## Templates
 


### PR DESCRIPTION
Added theiskaa.com the real world implementation example of Yew, under the Projects tag:

<img alt="Screen Shot 2022-11-07 at 18 09 16" src="https://user-images.githubusercontent.com/59066341/200330655-5e5fd149-8aeb-4ae3-9707-349d5e055973.png">
